### PR TITLE
Add Linux Mint to supported distros

### DIFF
--- a/tasks/docker-install-LinuxMint.yml
+++ b/tasks/docker-install-LinuxMint.yml
@@ -1,0 +1,26 @@
+---
+- name: Linux Mint package installation
+  apt:
+    name: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items:
+    - apt-transport-https
+    - ca-certificates
+    - curl
+    - software-properties-common
+    - add-apt-key
+
+- name: add the docker key
+  apt_key:
+    url: https://download.docker.com/linux/debian/gpg
+    state: present
+
+- name: force add the stable channel
+  shell: /usr/bin/add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//') stable"
+
+- name: install docker-ce
+  apt:
+    name: docker-ce
+    state: present
+    update_cache: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   with_first_found:
     - files:
         - "docker-install-{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
-        - "docker-install-{{ ansible_distribution }}.yml"
+        - "docker-install-{{ ansible_distribution | replace(' ', '') }}.yml"
       skip: true
 
 ################################################################ 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # TODO: check distribution and version and fail if not valid
 
-- name: fail if not Ubuntu or Centos
+- name: fail if not Ubuntu, Centos, or Linux Mint
   fail: 
-    msg: "This role currently only support Ubuntu and CentOS"
-  when: ansible_distribution != "Ubuntu" and ansible_distribution != "CentOS"
+    msg: "This role currently only support Ubuntu, Linux Mint, and CentOS"
+  when: ansible_distribution != "Ubuntu" and ansible_distribution != "CentOS" and ansible_distribution != "Linux Mint"
 
 - name: fail if Ubuntu and not Ubuntu 14+
   fail: 

--- a/vars/LinuxMint.yml
+++ b/vars/LinuxMint.yml
@@ -1,0 +1,1 @@
+ansible_docker_execstart_base: "/usr/bin/dockerd -H fd://"


### PR DESCRIPTION
This PR adds Linux Mint to the supported distros.  Under the hood it's actually just installing the Debian package, since that's what the script at http://get.docker.com does if it detects you're using Mint.