### PR TITLE
use include_tasks instead of include, include has been deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 
 # tasks file for ansible-docker
 - name: INCLUDE; execute distribution specific tasks
-  include: "{{ item }}"
+  include_tasks: "{{ item }}"
   with_first_found:
     - files:
         - "docker-install-{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"


### PR DESCRIPTION
`include` has been deprecated, this is to get rid of the deprecation warning